### PR TITLE
Implement log trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,7 +74,7 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "custom-logger"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "colored",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,7 @@ name = "custom-logger"
 version = "0.1.4"
 dependencies = [
  "chrono",
+ "log",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "colored"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+dependencies = [
+ "lazy_static",
+ "windows-sys",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,6 +77,7 @@ name = "custom-logger"
 version = "0.1.4"
 dependencies = [
  "chrono",
+ "colored",
  "log",
 ]
 
@@ -101,6 +112,12 @@ checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -248,14 +265,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.52.4"
+name = "windows-sys"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
  "windows_i686_gnu",
+ "windows_i686_gnullvm",
  "windows_i686_msvc",
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
@@ -264,42 +291,48 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
 log = { version = "0.4", features = ["std"] }
+colored = "2"
 
 [lib]
 name = "custom_logger"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
+log = { version = "0.4", features = ["std"] }
 
 [lib]
 name = "custom_logger"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "custom-logger"
-version = "0.1.4"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,250 +1,174 @@
 use chrono::{DateTime, Local};
 
-// logging convenience functions
-#[derive(Eq, PartialEq)]
-pub enum Level {
-    INFO,
-    DEBUG,
-    TRACE,
-    WARN,
-}
-
 //#[derive(Default)]
 pub struct Logging {
-    pub log_level: Level,
+    log_level: log::LevelFilter,
+}
+
+// Re-export so they can be used from the same crate
+pub use log::{debug, error, info, trace, warn, LevelFilter};
+
+#[macro_export]
+macro_rules! hi {
+    ($($arg:tt)+) => ({
+        let msg = format_args!($($arg)+);
+        log::info!("{}", $crate::Logging::hi(msg.as_str().unwrap_or("")));
+    })
+}
+
+#[macro_export]
+macro_rules! mid {
+    ($($arg:tt)+) => ({
+        let msg = format_args!($($arg)+);
+        log::info!("{}", $crate::Logging::mid(msg.as_str().unwrap_or("")));
+    })
+}
+
+#[macro_export]
+macro_rules! lo {
+    ($($arg:tt)+) => ({
+        let msg = format_args!($($arg)+);
+        log::info!("{}", $crate::Logging::lo(msg.as_str().unwrap_or("")));
+    })
+}
+
+#[macro_export]
+macro_rules! ex {
+    ($($arg:tt)+) => ({
+        let msg = format_args!($($arg)+);
+        log::info!("{}", $crate::Logging::ex(msg.as_str().unwrap_or("")));
+    })
+}
+
+impl log::Log for Logging {
+    fn enabled(&self, metadata: &log::Metadata) -> bool {
+        metadata.level().to_level_filter() <= self.log_level
+    }
+
+    fn log(&self, record: &log::Record) {
+        let dt = Local::now();
+        let dt_new = DateTime::<Local>::from_naive_utc_and_offset(dt.naive_utc(), *dt.offset());
+        let dt_formated = dt_new.format("%Y-%m-%d %H:%M:%S%.3f");
+
+        let level_log = match record.level() {
+            log::Level::Info => format!("\x1b[1;94m [ INFO  {} ] \x1b[0m", dt_formated),
+            log::Level::Debug => format!("\x1b[1;92m [ DEBUG {} ] \x1b[0m", dt_formated),
+            log::Level::Trace => format!("\x1b[1;96m [ TRACE {} ] \x1b[0m", dt_formated),
+            log::Level::Warn => format!("\x1b[1;93m [ WARN  {} ] \x1b[0m", dt_formated),
+            log::Level::Error => format!("\x1b[1;91m [ ERROR {} ] \x1b[0m", dt_formated),
+        };
+
+        println!("{} : {}", level_log, record.args());
+    }
+
+    fn flush(&self) {}
 }
 
 impl Logging {
-    // info
-    pub fn info(&self, msg: &str) {
-        if self.log_level == Level::INFO
-            || self.log_level == Level::DEBUG
-            || self.log_level == Level::TRACE
-        {
-            let dt = Local::now();
-            let naive_utc = dt.naive_utc();
-            let offset = dt.offset().clone();
-            let dt_new = DateTime::<Local>::from_naive_utc_and_offset(naive_utc, offset);
-            let dt_formated = dt_new.format("%Y-%m-%d %H:%M:%S%.3f");
-            println!(
-                "\x1b[1;94m [ {} {} ] \x1b[0m  : {}",
-                "INFO ", dt_formated, msg
-            );
+    #[allow(clippy::new_without_default)]
+    #[must_use = "You must call init() to begin logging"]
+    pub fn new() -> Self {
+        Self {
+            log_level: LevelFilter::Info,
         }
     }
-    /// debug
-    pub fn debug(&self, msg: &str) {
-        let dt = Local::now();
-        let naive_utc = dt.naive_utc();
-        let offset = dt.offset().clone();
-        let dt_new = DateTime::<Local>::from_naive_utc_and_offset(naive_utc, offset);
-        let dt_formated = dt_new.format("%Y-%m-%d %H:%M:%S%.3f");
-        if self.log_level == Level::DEBUG || self.log_level == Level::TRACE {
-            println!(
-                "\x1b[1;92m [ {} {} ] \x1b[0m  : {}",
-                "DEBUG", dt_formated, msg
-            );
-        }
+
+    #[must_use = "You must call init() to begin logging"]
+    pub fn with_level(mut self, level: LevelFilter) -> Self {
+        self.log_level = level;
+        self
     }
-    /// info with highlight
-    pub fn hi(&self, msg: &str) {
-        if self.log_level == Level::INFO
-            || self.log_level == Level::DEBUG
-            || self.log_level == Level::TRACE
-        {
-            let dt = Local::now();
-            let naive_utc = dt.naive_utc();
-            let offset = dt.offset().clone();
-            let dt_new = DateTime::<Local>::from_naive_utc_and_offset(naive_utc, offset);
-            let dt_formated = dt_new.format("%Y-%m-%d %H:%M:%S%.3f");
-            println!(
-                "\x1b[1;94m [ {}  {} ] \x1b[0m  : \x1b[1;93m{} \x1b[0m",
-                "INFO", dt_formated, msg
-            );
-        }
+
+    pub fn init(self) -> Result<(), log::SetLoggerError> {
+        log::set_max_level(self.log_level);
+        log::set_boxed_logger(Box::new(self))
     }
-    /// info with mid level highlight
-    pub fn mid(&self, msg: &str) {
-        if self.log_level == Level::INFO
-            || self.log_level == Level::DEBUG
-            || self.log_level == Level::TRACE
-        {
-            let dt = Local::now();
-            let naive_utc = dt.naive_utc();
-            let offset = dt.offset().clone();
-            let dt_new = DateTime::<Local>::from_naive_utc_and_offset(naive_utc, offset);
-            let dt_formated = dt_new.format("%Y-%m-%d %H:%M:%S%.3f");
-            println!(
-                "\x1b[1;94m [ {}  {} ]  \x1b[0m : \x1b[1;94m{} \x1b[0m",
-                "INFO", dt_formated, msg
-            );
-        }
+
+    pub fn hi(s: &str) -> String {
+        format!("\x1b[1;93m{} \x1b[0m", s)
     }
-    // info with low level highlight
-    pub fn lo(&self, msg: &str) {
-        if self.log_level == Level::INFO
-            || self.log_level == Level::DEBUG
-            || self.log_level == Level::TRACE
-        {
-            let dt = Local::now();
-            let naive_utc = dt.naive_utc();
-            let offset = dt.offset().clone();
-            let dt_new = DateTime::<Local>::from_naive_utc_and_offset(naive_utc, offset);
-            let dt_formated = dt_new.format("%Y-%m-%d %H:%M:%S%.3f");
-            println!(
-                "\x1b[1;94m [ {}  {} ]  \x1b[0m : \x1b[1;95m{} \x1b[0m",
-                "INFO", dt_formated, msg
-            );
-        }
+
+    pub fn mid(s: &str) -> String {
+        format!("\x1b[1;94m{} \x1b[0m", s)
     }
-    // info with extra level highlight
-    pub fn ex(&self, msg: &str) {
-        if self.log_level == Level::INFO
-            || self.log_level == Level::DEBUG
-            || self.log_level == Level::TRACE
-        {
-            let dt = Local::now();
-            let naive_utc = dt.naive_utc();
-            let offset = dt.offset().clone();
-            let dt_new = DateTime::<Local>::from_naive_utc_and_offset(naive_utc, offset);
-            let dt_formated = dt_new.format("%Y-%m-%d %H:%M:%S%.3f");
-            println!(
-                "\x1b[1;94m [ {}  {} ]  \x1b[0m : \x1b[1;98m{} \x1b[0m",
-                "INFO", dt_formated, msg
-            );
-        }
+
+    pub fn lo(s: &str) -> String {
+        format!("\x1b[1;95m{} \x1b[0m", s)
     }
-    /// trace
-    pub fn trace(&self, msg: &str) {
-        let dt = Local::now();
-        let naive_utc = dt.naive_utc();
-        let offset = dt.offset().clone();
-        let dt_new = DateTime::<Local>::from_naive_utc_and_offset(naive_utc, offset);
-        let dt_formated = dt_new.format("%Y-%m-%d %H:%M:%S%.3f");
-        if self.log_level == Level::TRACE {
-            println!(
-                "\x1b[1;96m [ {} {} ] \x1b[0m  : {}",
-                "TRACE", dt_formated, msg
-            );
-        }
-    }
-    /// warning
-    pub fn warn(&self, msg: &str) {
-        let dt = Local::now();
-        let naive_utc = dt.naive_utc();
-        let offset = dt.offset().clone();
-        let dt_new = DateTime::<Local>::from_naive_utc_and_offset(naive_utc, offset);
-        let dt_formated = dt_new.format("%Y-%m-%d %H:%M:%S%.3f");
-        println!(
-            "\x1b[1;93m [ {}  {} ] \x1b[0m  : {}",
-            "WARN", dt_formated, msg
-        );
-    }
-    /// error
-    pub fn error(&self, msg: &str) {
-        let dt = Local::now();
-        let naive_utc = dt.naive_utc();
-        let offset = dt.offset().clone();
-        let dt_new = DateTime::<Local>::from_naive_utc_and_offset(naive_utc, offset);
-        let dt_formated = dt_new.format("%Y-%m-%d %H:%M:%S%.3f");
-        println!(
-            "\x1b[1;91m [ {} {} ] \x1b[0m  : {}",
-            "ERROR", dt_formated, msg
-        );
+
+    pub fn ex(s: &str) -> String {
+        format!("\x1b[1;98m{} \x1b[0m", s)
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use log::{Level, Log};
+
     // this brings everything from parent's scope into this scope
     use super::*;
 
     #[test]
+    fn test_logging() {
+        let log = Logging::new().with_level(LevelFilter::Trace);
+        log.init().expect("should initialize");
+        info!("testing info logging");
+        debug!("testing debug logging");
+        trace!("testing trace logging");
+        warn!("testing warn logging");
+        error!("testing error logging");
+        mid!("testing mid logging");
+        hi!("testing hi logging");
+        lo!("testing lo logging");
+        ex!("testing ex logging");
+    }
+
+    #[test]
     fn test_info_pass() {
-        let log = &Logging {
-            log_level: Level::INFO,
-        };
-        log.info("testing info logging");
+        let log = Logging::new().with_level(LevelFilter::Info);
+        assert!(log.enabled(&log::Metadata::builder().level(Level::Info).build()));
+        assert!(log.enabled(&log::Metadata::builder().level(Level::Error).build()));
+        assert!(log.enabled(&log::Metadata::builder().level(Level::Warn).build()));
+        assert!(!log.enabled(&log::Metadata::builder().level(Level::Debug).build()));
+        assert!(!log.enabled(&log::Metadata::builder().level(Level::Trace).build()));
     }
 
     #[test]
     fn test_debug_pass() {
-        let log = &Logging {
-            log_level: Level::DEBUG,
-        };
-        log.debug("testing debug logging");
+        let log = Logging::new().with_level(LevelFilter::Debug);
+        assert!(log.enabled(&log::Metadata::builder().level(Level::Debug).build()));
+        assert!(log.enabled(&log::Metadata::builder().level(Level::Info).build()));
+        assert!(log.enabled(&log::Metadata::builder().level(Level::Error).build()));
+        assert!(log.enabled(&log::Metadata::builder().level(Level::Warn).build()));
+        assert!(!log.enabled(&log::Metadata::builder().level(Level::Trace).build()));
     }
 
     #[test]
     fn test_trace_pass() {
-        let log = &Logging {
-            log_level: Level::TRACE,
-        };
-        log.trace("testing trace logging");
+        let log = Logging::new().with_level(LevelFilter::Trace);
+        assert!(log.enabled(&log::Metadata::builder().level(Level::Trace).build()));
+        assert!(log.enabled(&log::Metadata::builder().level(Level::Info).build()));
+        assert!(log.enabled(&log::Metadata::builder().level(Level::Error).build()));
+        assert!(log.enabled(&log::Metadata::builder().level(Level::Warn).build()));
+        assert!(log.enabled(&log::Metadata::builder().level(Level::Debug).build()));
     }
 
     #[test]
     fn test_warn_pass() {
-        let log = &Logging {
-            log_level: Level::WARN,
-        };
-        log.warn("testing warn logging");
-    }
-
-    #[test]
-    fn test_mid_pass() {
-        let log = &Logging {
-            log_level: Level::INFO,
-        };
-        log.mid("testing mid logging");
-    }
-
-    #[test]
-    fn test_hi_pass() {
-        let log = &Logging {
-            log_level: Level::INFO,
-        };
-        log.hi("testing hi logging");
-    }
-
-    #[test]
-    fn test_lo_pass() {
-        let log = &Logging {
-            log_level: Level::INFO,
-        };
-        log.lo("testing lo logging");
-    }
-
-    #[test]
-    fn test_ex_pass() {
-        let log = &Logging {
-            log_level: Level::INFO,
-        };
-        log.ex("testing ex logging");
+        let log = Logging::new().with_level(LevelFilter::Warn);
+        assert!(log.enabled(&log::Metadata::builder().level(Level::Warn).build()));
+        assert!(log.enabled(&log::Metadata::builder().level(Level::Error).build()));
+        assert!(!log.enabled(&log::Metadata::builder().level(Level::Info).build()));
+        assert!(!log.enabled(&log::Metadata::builder().level(Level::Trace).build()));
     }
 
     #[test]
     fn test_error_pass() {
-        let log = &Logging {
-            log_level: Level::INFO,
-        };
-        log.error("testing error logging");
-    }
-
-    // set level to TRACE
-    #[test]
-    fn test_mid_with_trace_pass() {
-        let log = &Logging {
-            log_level: Level::TRACE,
-        };
-        log.mid("testing mid logging with TRACE");
-    }
-
-    #[test]
-    fn test_hi_with_trace_pass() {
-        let log = &Logging {
-            log_level: Level::TRACE,
-        };
-        log.hi("testing hi logging with TRACE");
+        let log = Logging::new().with_level(LevelFilter::Error);
+        assert!(log.enabled(&log::Metadata::builder().level(Level::Error).build()));
+        assert!(!log.enabled(&log::Metadata::builder().level(Level::Warn).build()));
+        assert!(!log.enabled(&log::Metadata::builder().level(Level::Info).build()));
+        assert!(!log.enabled(&log::Metadata::builder().level(Level::Debug).build()));
+        assert!(!log.enabled(&log::Metadata::builder().level(Level::Trace).build()));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, Local};
+use colored::Colorize;
 
 //#[derive(Default)]
 pub struct Logging {
@@ -51,11 +52,11 @@ impl log::Log for Logging {
         let dt_formated = dt_new.format("%Y-%m-%d %H:%M:%S%.3f");
 
         let level_log = match record.level() {
-            log::Level::Info => format!("\x1b[1;94m [ INFO  {} ] \x1b[0m", dt_formated),
-            log::Level::Debug => format!("\x1b[1;92m [ DEBUG {} ] \x1b[0m", dt_formated),
-            log::Level::Trace => format!("\x1b[1;96m [ TRACE {} ] \x1b[0m", dt_formated),
-            log::Level::Warn => format!("\x1b[1;93m [ WARN  {} ] \x1b[0m", dt_formated),
-            log::Level::Error => format!("\x1b[1;91m [ ERROR {} ] \x1b[0m", dt_formated),
+            log::Level::Info => format!("[ INFO  {} ]", dt_formated).bright_blue().bold(),
+            log::Level::Debug => format!("[ DEBUG {} ]", dt_formated).bright_green().bold(),
+            log::Level::Trace => format!("[ TRACE {} ]", dt_formated).bright_cyan().bold(),
+            log::Level::Warn => format!("[ WARN  {} ]", dt_formated).bright_yellow().bold(),
+            log::Level::Error => format!("[ ERROR {} ]", dt_formated).bright_red().bold(),
         };
 
         println!("{} : {}", level_log, record.args());
@@ -84,20 +85,20 @@ impl Logging {
         log::set_boxed_logger(Box::new(self))
     }
 
-    pub fn hi(s: &str) -> String {
-        format!("\x1b[1;93m{} \x1b[0m", s)
+    pub fn hi(s: &str) -> colored::ColoredString {
+        s.bright_yellow().bold()
     }
 
-    pub fn mid(s: &str) -> String {
-        format!("\x1b[1;94m{} \x1b[0m", s)
+    pub fn mid(s: &str) -> colored::ColoredString {
+        s.bright_blue().bold()
     }
 
-    pub fn lo(s: &str) -> String {
-        format!("\x1b[1;95m{} \x1b[0m", s)
+    pub fn lo(s: &str) -> colored::ColoredString {
+        s.bright_purple().bold()
     }
 
-    pub fn ex(s: &str) -> String {
-        format!("\x1b[1;98m{} \x1b[0m", s)
+    pub fn ex(s: &str) -> colored::ColoredString {
+        s.bright_white().bold()
     }
 }
 


### PR DESCRIPTION
This is an alternative to https://github.com/lmzuccarelli/rust-custom-logger/pull/1 which implements the `log` trait, therefore using macros for the logging calls.
It also uses the `colored` crate for terminal colors.